### PR TITLE
update site key in _config.yml to HTTPS URL (hopefully fixes #7)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ keep_files:
 # Site settings
 title: HPC-UK
 subtitle: "Improving use of UK HPC faclities"
-url: "http://www.hpc-uk.ac.uk" # the base hostname & protocol for your site
+url: "https://www.hpc-uk.ac.uk" # the base hostname & protocol for your site
 # baseurl: "/the/subpath/of/your/site" # Set this value to "" if you want your site to be root
 baseurl: ""
 cover: "/assets/cover.png"


### PR DESCRIPTION
The site is now served over HTTPS with a Lets Encrypt certificate. This means that all the resources on the pages need to be loaded over HTTPS as well to prevent the mixed content warning. Updating the `site` key should flow through to the Jekyll variable `site.url`.